### PR TITLE
Add 'apply_quantification' and 'rename_variable(s)' functions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,4 @@ crate-type = ["cdylib", "staticlib"]
 
 
 [dependencies]
-biodivine-lib-bdd = "0.5"
+biodivine-lib-bdd = "0.5.17"


### PR DESCRIPTION
Adds `and_exists`, `or_exists`, `and_forall`, and `or_forall` together with `rename_variable` and `rename_variables`.

I have tested that `and_exists` and `rename_variables` works as intended.