### PR TITLE
Add `bdd_load`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -454,7 +454,7 @@ pub unsafe extern "C" fn bdd_pickcube(f: bdd_t) -> bdd_assignment_t {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn bdd_writebytes(f: bdd_t, path: *const std::ffi::c_char) -> () {
+pub unsafe extern "C" fn bdd_save(f: bdd_t, path: *const std::ffi::c_char) -> () {
     let f = unsafe { &**f._p };
     let f_bytes = f.to_bytes();
 


### PR DESCRIPTION
Adds `bdd_load` to circumvent the fact, that using the *builder pattern* with LibBDD is not a good idea; LibBDD runs out of memory while loading its own BDDs. Furthermore, I renamed `bdd_writebytes` to `bdd_save` for consistency.