### PR TITLE
Update Corrosion version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ include(FetchContent)
 FetchContent_Declare(
     Corrosion
     GIT_REPOSITORY https://github.com/corrosion-rs/corrosion.git
-    GIT_TAG v0.5.0
+    GIT_TAG v0.5.2
 )
 FetchContent_MakeAvailable(Corrosion)
 


### PR DESCRIPTION
With v0.5.0 only, building the benchmarks breaks